### PR TITLE
Stop relying only on isHubCluster to enable the unsealJob

### DIFF
--- a/templates/vault/golang-external-secrets-hub-secretstore.yaml
+++ b/templates/vault/golang-external-secrets-hub-secretstore.yaml
@@ -1,4 +1,10 @@
 {{- if or (eq .Values.global.secretStore.backend "vault") (not (hasKey .Values.global.secretStore "backend")) }}
+{{- $hashicorp_vault_found := false }}
+{{- range .Values.clusterGroup.applications }}
+  {{- if eq .chart "hashicorp-vault" }}
+    {{- $hashicorp_vault_found = true }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
@@ -13,7 +19,7 @@ spec:
       # Version of KV backend
       version: v2
 {{- if .Values.golangExternalSecrets.caProvider.enabled }}
-{{ if .Values.clusterGroup.isHubCluster }}
+{{ if or .Values.clusterGroup.isHubCluster $hashicorp_vault_found }}
       caProvider:
         type: {{ .Values.golangExternalSecrets.caProvider.hostCluster.type }}
         name: {{ .Values.golangExternalSecrets.caProvider.hostCluster.name }}
@@ -29,7 +35,7 @@ spec:
 {{- end }}
       auth:
         kubernetes:
-{{ if .Values.clusterGroup.isHubCluster }}
+{{ if or .Values.clusterGroup.isHubCluster $hashicorp_vault_found }}
           mountPath: {{ .Values.golangExternalSecrets.vault.mountPath }}
           role: {{ .Values.golangExternalSecrets.rbac.rolename }}
 {{ else }}

--- a/tests/golang_external_secrets_secretstore_test.yaml
+++ b/tests/golang_external_secrets_secretstore_test.yaml
@@ -95,6 +95,48 @@ tests:
           path: spec.provider.vault.caProvider.namespace
           value: foo
 
+  - it: should set the caProvider to the hostCluster when hashicorp-vault is set but isHubCluster is false
+    set:
+      clusterGroup:
+        isHubCluster: false
+        applications:
+          acm:
+            name: acm
+            namespace: open-cluster-management
+            project: hub
+            chart: acm
+            chartVersion: 0.1.*
+            ignoreDifferences:
+              - group: internal.open-cluster-management.io
+                kind: ManagedClusterInfo
+                jsonPointers:
+                  - /spec/loggingCA
+          vault:
+            name: vault
+            namespace: vault
+            project: hub
+            chart: hashicorp-vault
+            chartVersion: 0.1.*
+      golangExternalSecrets:
+        caProvider:
+          hostCluster:
+            name: bar-bar-configmap
+            key: bar-key
+            namespace: bar
+    asserts:
+      - equal:
+          path: spec.provider.vault.caProvider.type
+          value: ConfigMap
+      - equal:
+          path: spec.provider.vault.caProvider.name
+          value: bar-bar-configmap
+      - equal:
+          path: spec.provider.vault.caProvider.key
+          value: bar-key
+      - equal:
+          path: spec.provider.vault.caProvider.namespace
+          value: bar
+
   - it: should set the caProvider to the clientCluster when not on the hub
     set:
       clusterGroup:


### PR DESCRIPTION
Eventually we would like to drop isHubCluster as it is confusing and its
meaning does not always make sense (think of a standalone mcg setup.
I.e. one without ACM at all).

So let's enable the unsealJob either when isHubCluster is set to true
(in order to not break compatibility) or when in the application we
have the "hashicorp-vault" chart.

Tested on a standalone target for mcg and everything worked correctly.
